### PR TITLE
Fix None message body error

### DIFF
--- a/signallama.py
+++ b/signallama.py
@@ -205,7 +205,10 @@ class SignalLLMBridge:
                              envelope.get('sourceName'))
                     
                     # Get message content
-                    body = data_message.get('message', '').strip()
+                    raw_body = data_message.get('message', '')
+                    if raw_body is None:
+                        raw_body = ''
+                    body = raw_body.strip()
                     
                     if not author or not body:
                         logger.debug("Missing author (%s) or body (%s), skipping", author, body)


### PR DESCRIPTION
## Summary
- handle cases where message content is `None`

## Testing
- `python -m py_compile signallama.py`


------
https://chatgpt.com/codex/tasks/task_e_683d5989d8f4832d894b8c3982a22653